### PR TITLE
CampbellCochrane.jl

### DIFF
--- a/examples/AssetPricing/CampbellCochrane.jl
+++ b/examples/AssetPricing/CampbellCochrane.jl
@@ -67,7 +67,7 @@ y, result, distance = pdesolve(m, stategrid, y0)
 
 
 # Wachter (2005) calibration
-# m = CampbellCochraneModel(μ = 0.022, σ = 0.0086, γ = 2.0, ρ = 0.073, κs = 0.116, b = 0.011 * 4)
+# m = CampbellCochraneModel(μ = 0.022, σ = 0.0086, γ = 2.0, ρ = 0.073, κs = 0.116, b = 0.011)
 # stategrid = initialize_stategrid(m)
 # y0 = initialize_y(m, stategrid)
 # y, result, distance = pdesolve(m, stategrid, y0)


### PR DESCRIPTION
Parameter is already annualized. Checked against published Wachter (2005) FRL paper.
b should be .011, without "*4" bit.